### PR TITLE
Fix duplicate AllowCrossDeviceClipboard entries

### DIFF
--- a/CIS_WindowsServer2019_v110.ps1
+++ b/CIS_WindowsServer2019_v110.ps1
@@ -2001,7 +2001,7 @@ Configuration CIS_WindowsServer2019_v110 {
       }
        
        # 18.8.31.2 (L2) Ensure 'Allow upload of User Activities' is set to 'Disabled'
-       Registry 'AllowCrossDeviceClipboard' {
+       Registry 'UploadUserActivities' {
          Ensure     = 'Present'
          Key        = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System'
          ValueName  = 'UploadUserActivities'


### PR DESCRIPTION
There are 2 entries named "AllowCrossDeviceClipboard", which causes a "Duplicate Resource Identifier" error.

This change gives a unique name to the second entry based on the registry key it is modifying, similar to the other entries.