### PR TITLE
Add 18.8.4.1, renumber 18.8.4.2

### DIFF
--- a/CIS_WindowsServer2019_v110.ps1
+++ b/CIS_WindowsServer2019_v110.ps1
@@ -1649,7 +1649,17 @@ Configuration CIS_WindowsServer2019_v110 {
           ValueData  = '0'
        }
 
-       #  18.8.4.1 (L1) Ensure 'Remote host allows delegation of non-exportable credentials' is set to 'Enabled'
+       #  18.8.4.1 (L1) Ensure 'Encryption Oracle Remediation' Is Set to 'Enabled: Force Updated Clients'
+       Registry 'AllowEncryptionOracle' 
+       {
+          Ensure     = 'Present'
+          Key        = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\CredSSP\Parameters'
+          ValueName  = 'AllowEncryptionOracle'
+          ValueType  = 'DWord'
+          ValueData  = '0'
+       }
+
+       #  18.8.4.2 (L1) Ensure 'Remote host allows delegation of non-exportable credentials' is set to 'Enabled'
        Registry 'AllowProtectedCreds' {
           Ensure     = 'Present'
           Key        = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation'


### PR DESCRIPTION
18.8.4.2 (L1) was mislabeled as 18.8.4.1. 18.8.4.1 (L1) Ensure 'Encryption Oracle Remediation' Is Set to 'Enabled: Force Updated Clients' was missing. Ppdated labeling on check "Ensure 'Remote host allows delegation of non-exportable credentials' is set to 'Enabled'" after adding "Ensure 'Encryption Oracle Remediation' Is Set to 'Enabled: Force Updated Clients'"