### PR TITLE
FIX duplicate resource identifier

### DIFF
--- a/CIS_WindowsServer2019_v110.ps1
+++ b/CIS_WindowsServer2019_v110.ps1
@@ -2001,7 +2001,7 @@ Configuration CIS_WindowsServer2019_v110 {
       }
        
        # 18.8.31.2 (L2) Ensure 'Allow upload of User Activities' is set to 'Disabled'
-       Registry 'AllowCrossDeviceClipboard' {
+       Registry 'UploadUserActivities' {
          Ensure     = 'Present'
          Key        = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System'
          ValueName  = 'UploadUserActivities'


### PR DESCRIPTION
Fixing Windows Server 2019  ps1 script bug duplicated resource identifier AllowCrossDeviceClipboard

PSDesiredStateConfiguration\Registry : A duplicate resource identifier '[Registry]AllowCrossDeviceClipboard' was found while processing the specification for node 'localhost'. Change the name of this resource so that it is 
unique within the node specification.