### PR TITLE
Correct value for AllowEncryptionOracle

### DIFF
--- a/CIS_Windows10_v181.ps1
+++ b/CIS_Windows10_v181.ps1
@@ -1908,7 +1908,7 @@ Configuration CIS_Windows10_v181 {
             Key        = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\CredSSP\Parameters'
             ValueName  = 'AllowEncryptionOracle'
             ValueType  = 'DWord'
-            ValueData  = '2'
+            ValueData  = '0'
         }
 
         # 18.8.4.2 (L1) Ensure 'Remote host allows delegation of non-exportable credentials' is set to 'Enabled'


### PR DESCRIPTION
Correct value for AllowEncryptionOracle is 0 for "Force Updated Clients" as per https://support.microsoft.com/en-us/topic/credssp-updates-for-cve-2018-0886-5cbf9e5f-dc6d-744f-9e97-7ba400d6d3ea